### PR TITLE
Updating global state based on transactions

### DIFF
--- a/app/components/account-summary.tsx
+++ b/app/components/account-summary.tsx
@@ -97,6 +97,8 @@ export default function AccountSummary() {
           className="bg-green-300 mr-2 h-2 rounded-full"
           style={{
             background: "linear-gradient(270deg, #1BD6CF 0%, #00E5AF 100%)",
+            width: 0,
+            transition: "width 1s ease-out",
           }}
           ref={leftLineRef}
         ></div>

--- a/app/components/borrow-flow/borrow.tsx
+++ b/app/components/borrow-flow/borrow.tsx
@@ -1,6 +1,6 @@
 import { ICON_SIZE } from "~/lib/constants";
 import type { Market, TokenPair } from "~/types/global";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useContext } from "react";
 import type { JsonRpcSigner } from "@ethersproject/providers";
 
 import clsx from "clsx";
@@ -16,6 +16,7 @@ import { useCurrentlyBorrowing } from "~/hooks/use-currently-borrowing";
 
 import ConfirmingTransaction from "../fi-modal/confirming-transition";
 import { useMaxBorrowAmountForToken } from "~/hooks/use-max-borrow-amount-for-token";
+import { TenderContext } from "~/contexts/tender-context";
 
 interface Props {
   market: Market;
@@ -49,6 +50,8 @@ export default function Borrow({
     market.tokenPair.token
   );
   let isValid = useValidInput(value, 0, borrowLimit);
+
+  let { updateTransaction } = useContext(TenderContext);
 
   let newBorrowLimit = useProjectBorrowLimit(
     signer,
@@ -189,9 +192,9 @@ export default function Borrow({
                           );
 
                           setIsWaitingToBeMined(true);
-                          await txn.wait(); // TODO: error handle if transaction fails
+                          let tr = await txn.wait(); // TODO: error handle if transaction fails
                           setIsWaitingToBeMined(false);
-                          //   setValue("");
+                          updateTransaction(tr.blockHash);
                           toast.success("Borrow successful");
                           closeModal();
                         } catch (e) {

--- a/app/components/borrow-flow/repay.tsx
+++ b/app/components/borrow-flow/repay.tsx
@@ -1,6 +1,6 @@
 import { ICON_SIZE } from "~/lib/constants";
 import type { Market, TokenPair } from "~/types/global";
-import { useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import type { JsonRpcSigner } from "@ethersproject/providers";
 
 import clsx from "clsx";
@@ -15,6 +15,7 @@ import { useProjectBorrowLimit } from "~/hooks/use-project-borrow-limit";
 import { useBorrowLimitUsed } from "~/hooks/use-borrow-limit-used";
 
 import ConfirmingTransaction from "../fi-modal/confirming-transition";
+import { TenderContext } from "~/contexts/tender-context";
 
 interface Props {
   closeModal: Function;

--- a/app/components/borrow-flow/repay.tsx
+++ b/app/components/borrow-flow/repay.tsx
@@ -65,6 +65,8 @@ export default function Repay({
     newBorrowLimit
   );
 
+  let { updateTransaction } = useContext(TenderContext);
+
   useEffect(() => {
     if (!signer) {
       return;
@@ -240,10 +242,10 @@ export default function Repay({
                         );
 
                         setIsWaitingToBeMined(true);
-                        await txn.wait(); // TODO: error handle if transaction fails
+                        let tr = await txn.wait(); // TODO: error handle if transaction fails
                         setIsWaitingToBeMined(false);
-
                         setValue("");
+                        updateTransaction(tr.blockHash);
                         toast.success("Repayment successful");
                         closeModal();
                       } catch (e) {

--- a/app/components/deposit-flow/deposit.tsx
+++ b/app/components/deposit-flow/deposit.tsx
@@ -1,7 +1,10 @@
 import { ICON_SIZE } from "~/lib/constants";
 import type { Market } from "~/types/global";
 import { useContext, useEffect, useRef, useState } from "react";
-import type { JsonRpcSigner } from "@ethersproject/providers";
+import type {
+  JsonRpcSigner,
+  TransactionReceipt,
+} from "@ethersproject/providers";
 import { useValidInput } from "~/hooks/use-valid-input";
 import toast from "react-hot-toast";
 import Max from "~/components/max";
@@ -44,7 +47,7 @@ export default function Deposit({
   let inputEl = useRef<HTMLInputElement>(null);
   let isValid = useValidInput(value, 0, walletBalance);
 
-  let { tokenPairs } = useContext(TenderContext);
+  let { tokenPairs, updateTransaction } = useContext(TenderContext);
 
   let newBorrowLimit = useProjectBorrowLimit(
     signer,
@@ -229,9 +232,10 @@ export default function Deposit({
                         market.tokenPair.token
                       );
                       setIsWaitingToBeMined(true);
-                      await txn.wait();
+                      let tr = await txn.wait();
                       setIsWaitingToBeMined(false);
                       setValue("");
+                      updateTransaction(tr.blockHash);
                       toast.success("Deposit successful");
                       closeModal();
                     } catch (e) {

--- a/app/components/deposit-flow/deposit.tsx
+++ b/app/components/deposit-flow/deposit.tsx
@@ -1,10 +1,7 @@
 import { ICON_SIZE } from "~/lib/constants";
 import type { Market } from "~/types/global";
 import { useContext, useEffect, useRef, useState } from "react";
-import type {
-  JsonRpcSigner,
-  TransactionReceipt,
-} from "@ethersproject/providers";
+import type { JsonRpcSigner } from "@ethersproject/providers";
 import { useValidInput } from "~/hooks/use-valid-input";
 import toast from "react-hot-toast";
 import Max from "~/components/max";

--- a/app/components/deposit-flow/withdraw.tsx
+++ b/app/components/deposit-flow/withdraw.tsx
@@ -41,7 +41,7 @@ export default function Withdraw({
   let inputEl = useRef<HTMLInputElement>(null);
   let isValid = useValidInput(value, 0, market.supplyBalance);
 
-  let { tokenPairs } = useContext(TenderContext);
+  let { tokenPairs, updateTransaction } = useContext(TenderContext);
 
   let newBorrowLimit = useProjectBorrowLimit(
     signer,
@@ -182,9 +182,10 @@ export default function Withdraw({
                           );
 
                           setBlockChaining(true);
-                          await txn.wait(); // TODO: error handle if transaction fails
+                          let tr = await txn.wait(); // TODO: error handle if transaction fails
                           setBlockChaining(false);
                           setValue("");
+                          updateTransaction(tr);
                           toast.success("Withdraw successful");
                           closeModal();
                         } catch (e) {

--- a/app/hooks/use-borrow-limit-used.ts
+++ b/app/hooks/use-borrow-limit-used.ts
@@ -1,11 +1,16 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
+import { TenderContext } from "~/contexts/tender-context";
 import { getBorrowLimitUsed } from "~/lib/tender";
+import { useInterval } from "./use-interval";
 
 export function useBorrowLimitUsed(
   borrowedAmount: number,
   borrowLimit: number
 ): string {
   let [borrowLimitUsed, setBorrowLimitUsed] = useState<string>("");
+
+  let { currentTransaction } = useContext(TenderContext);
+  let pollKey = useInterval(10_000);
 
   useEffect(() => {
     if (!borrowLimit) {
@@ -15,7 +20,7 @@ export function useBorrowLimitUsed(
     getBorrowLimitUsed(borrowedAmount, borrowLimit).then((b) =>
       setBorrowLimitUsed(b)
     );
-  }, [borrowedAmount, borrowLimit]);
+  }, [borrowedAmount, borrowLimit, currentTransaction, pollKey]);
 
   return borrowLimitUsed;
 }

--- a/app/hooks/use-borrow-limit.ts
+++ b/app/hooks/use-borrow-limit.ts
@@ -1,7 +1,9 @@
 import type { JsonRpcSigner } from "@ethersproject/providers";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
+import { TenderContext } from "~/contexts/tender-context";
 import { getAccountBorrowLimitInUsd } from "~/lib/tender";
 import type { TokenPair } from "~/types/global";
+import { useInterval } from "./use-interval";
 
 export function useBorrowLimit(
   signer: JsonRpcSigner | undefined,
@@ -9,6 +11,9 @@ export function useBorrowLimit(
   tokenPairs: TokenPair[]
 ): number {
   let [borrowLimit, setBorrowLimit] = useState<number>(0);
+
+  let { currentTransaction } = useContext(TenderContext);
+  let poll = useInterval(10_000);
 
   useEffect(() => {
     if (!signer || !tokenPairs) {
@@ -18,7 +23,7 @@ export function useBorrowLimit(
     getAccountBorrowLimitInUsd(signer, comptrollerAddress, tokenPairs).then(
       (b) => setBorrowLimit(b)
     );
-  }, [signer, comptrollerAddress, tokenPairs]);
+  }, [signer, comptrollerAddress, tokenPairs, poll, currentTransaction]);
 
   return borrowLimit;
 }

--- a/app/hooks/use-interval.ts
+++ b/app/hooks/use-interval.ts
@@ -4,11 +4,11 @@ export function useInterval(POLLING_RATE: number): number {
   let [buster, setBuster] = useState<number>(Date.now());
 
   useEffect(() => {
-      let id = setInterval(() => setBuster(Date.now()), POLLING_RATE)
-      return () => {
-          clearInterval(id);
-      }
-  }, []);
+    let id = setInterval(() => setBuster(Date.now()), POLLING_RATE);
+    return () => {
+      clearInterval(id);
+    };
+  }, [POLLING_RATE]);
 
   return buster;
 }

--- a/app/hooks/use-interval.ts
+++ b/app/hooks/use-interval.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from "react";
+
+export function useInterval(POLLING_RATE: number): number {
+  let [buster, setBuster] = useState<number>(Date.now());
+
+  useEffect(() => {
+      let id = setInterval(() => setBuster(Date.now()), POLLING_RATE)
+      return () => {
+          clearInterval(id);
+      }
+  }, []);
+
+  return buster;
+}

--- a/app/hooks/use-net-apy.ts
+++ b/app/hooks/use-net-apy.ts
@@ -1,5 +1,6 @@
 import type { JsonRpcSigner } from "@ethersproject/providers";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
+import { TenderContext } from "~/contexts/tender-context";
 import { netApy as netApyFn } from "~/lib/apy-calculations";
 import type { TokenPair } from "~/types/global";
 import { useInterval } from "./use-interval";
@@ -9,6 +10,7 @@ export function useNetApy(
   tokenPairs: TokenPair[]
 ) {
   let [netApy, setNetApy] = useState<number | null>(null);
+  let { currentTransaction } = useContext(TenderContext);
   let poll = useInterval(10_000);
 
   useEffect(() => {
@@ -16,7 +18,7 @@ export function useNetApy(
       return;
     }
     netApyFn(signer, tokenPairs).then((n) => setNetApy(n));
-  }, [signer, tokenPairs, poll]);
+  }, [signer, tokenPairs, poll, currentTransaction]);
 
   return netApy;
 }

--- a/app/hooks/use-net-apy.ts
+++ b/app/hooks/use-net-apy.ts
@@ -2,19 +2,21 @@ import type { JsonRpcSigner } from "@ethersproject/providers";
 import { useState, useEffect } from "react";
 import { netApy as netApyFn } from "~/lib/apy-calculations";
 import type { TokenPair } from "~/types/global";
+import { useInterval } from "./use-interval";
 
 export function useNetApy(
   signer: JsonRpcSigner | undefined,
   tokenPairs: TokenPair[]
 ) {
   let [netApy, setNetApy] = useState<number | null>(null);
+  let poll = useInterval(10_000);
 
   useEffect(() => {
     if (!signer) {
       return;
     }
     netApyFn(signer, tokenPairs).then((n) => setNetApy(n));
-  }, [signer, tokenPairs]);
+  }, [signer, tokenPairs, poll]);
 
   return netApy;
 }

--- a/app/hooks/use-tender-context.ts
+++ b/app/hooks/use-tender-context.ts
@@ -5,13 +5,16 @@ import { useTokenPairs } from "./use-token-pairs";
 import { useOnSupportedNetwork } from "./use-on-supported-network";
 import { useNetworkData } from "./use-network-data";
 import { useMarkets } from "./use-markets";
+import { useInterval } from "./use-interval";
 
 export function useTenderContext() {
+  let [currentTransaction, updateTransaction] = useState<string | null>(null);
   let [tenderContext, setTenderContext] = useState<TenderContext | null>();
   const chainId = Web3Hooks.useChainId();
   let networkData = useNetworkData(chainId);
   let onSupportedNetwork = useOnSupportedNetwork(chainId);
   let tokenPairs = useTokenPairs(networkData, onSupportedNetwork);
+  let pollingNonce = useInterval(10_000);
 
   let markets: Market[] = useMarkets(
     tokenPairs,
@@ -23,12 +26,16 @@ export function useTenderContext() {
       return;
     }
 
+    console.log(Date.now());
+
     setTenderContext({
       tokenPairs,
       networkData,
       markets,
+      currentTransaction,
+      updateTransaction,
     });
-  }, [chainId, tokenPairs, networkData, markets]);
+  }, [pollingNonce, chainId, tokenPairs, networkData, markets]);
 
   return tenderContext;
 }

--- a/app/hooks/use-tender-context.ts
+++ b/app/hooks/use-tender-context.ts
@@ -26,8 +26,6 @@ export function useTenderContext() {
       return;
     }
 
-    console.log(Date.now());
-
     setTenderContext({
       tokenPairs,
       networkData,

--- a/app/hooks/use-tender-context.ts
+++ b/app/hooks/use-tender-context.ts
@@ -14,7 +14,7 @@ export function useTenderContext() {
   let networkData = useNetworkData(chainId);
   let onSupportedNetwork = useOnSupportedNetwork(chainId);
   let tokenPairs = useTokenPairs(networkData, onSupportedNetwork);
-  let pollingNonce = useInterval(10_000);
+  let pollingKey = useInterval(10_000);
 
   let markets: Market[] = useMarkets(
     tokenPairs,
@@ -35,7 +35,14 @@ export function useTenderContext() {
       currentTransaction,
       updateTransaction,
     });
-  }, [pollingNonce, chainId, tokenPairs, networkData, markets]);
+  }, [
+    pollingKey,
+    chainId,
+    tokenPairs,
+    networkData,
+    markets,
+    currentTransaction,
+  ]);
 
   return tenderContext;
 }

--- a/app/hooks/use-total-borrowed-in-usd.ts
+++ b/app/hooks/use-total-borrowed-in-usd.ts
@@ -1,7 +1,9 @@
 import type { JsonRpcSigner } from "@ethersproject/providers";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
+import { TenderContext } from "~/contexts/tender-context";
 import { getTotalBorrowedInUsd } from "~/lib/tender";
 import type { TokenPair } from "~/types/global";
+import { useInterval } from "./use-interval";
 
 export function useTotalBorrowedInUsd(
   signer: JsonRpcSigner | undefined,
@@ -9,6 +11,9 @@ export function useTotalBorrowedInUsd(
 ): number {
   let [totalBorrowedAmountInUsd, setTotalBorrowedAmountInUsd] =
     useState<number>(0);
+
+  let poll = useInterval(10_000);
+  let { currentTransaction } = useContext(TenderContext);
 
   useEffect(() => {
     if (!signer) {
@@ -18,7 +23,7 @@ export function useTotalBorrowedInUsd(
     getTotalBorrowedInUsd(signer, tokenPairs).then((b) =>
       setTotalBorrowedAmountInUsd(b)
     );
-  }, [signer, tokenPairs]);
+  }, [signer, tokenPairs, poll, currentTransaction]);
 
   return totalBorrowedAmountInUsd;
 }

--- a/app/hooks/use-total-supply-balance-in-usd.ts
+++ b/app/hooks/use-total-supply-balance-in-usd.ts
@@ -2,6 +2,7 @@ import type { JsonRpcSigner } from "@ethersproject/providers";
 import { useState, useEffect } from "react";
 import { getTotalSupplyBalanceInUsd } from "~/lib/tender";
 import type { TokenPair } from "~/types/global";
+import { useInterval } from "./use-interval";
 
 export function useTotalSupplyBalanceInUsd(
   signer: JsonRpcSigner | undefined,
@@ -9,6 +10,7 @@ export function useTotalSupplyBalanceInUsd(
 ) {
   let [totalSupplyBalanceInUsd, setTotalSupplyBalanceInUsd] =
     useState<number>(0);
+  let poll = useInterval(10_000);
 
   useEffect(() => {
     if (!signer || tokenPairs.length === 0) {
@@ -18,7 +20,7 @@ export function useTotalSupplyBalanceInUsd(
     getTotalSupplyBalanceInUsd(signer, tokenPairs).then((v) =>
       setTotalSupplyBalanceInUsd(v)
     );
-  }, [signer, tokenPairs]);
+  }, [signer, tokenPairs, poll]);
 
   return totalSupplyBalanceInUsd;
 }

--- a/app/hooks/use-total-supply-balance-in-usd.ts
+++ b/app/hooks/use-total-supply-balance-in-usd.ts
@@ -1,5 +1,6 @@
 import type { JsonRpcSigner } from "@ethersproject/providers";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
+import { TenderContext } from "~/contexts/tender-context";
 import { getTotalSupplyBalanceInUsd } from "~/lib/tender";
 import type { TokenPair } from "~/types/global";
 import { useInterval } from "./use-interval";
@@ -10,6 +11,7 @@ export function useTotalSupplyBalanceInUsd(
 ) {
   let [totalSupplyBalanceInUsd, setTotalSupplyBalanceInUsd] =
     useState<number>(0);
+  let { currentTransaction } = useContext(TenderContext);
   let poll = useInterval(10_000);
 
   useEffect(() => {
@@ -20,7 +22,7 @@ export function useTotalSupplyBalanceInUsd(
     getTotalSupplyBalanceInUsd(signer, tokenPairs).then((v) =>
       setTotalSupplyBalanceInUsd(v)
     );
-  }, [signer, tokenPairs, poll]);
+  }, [signer, tokenPairs, poll, currentTransaction]);
 
   return totalSupplyBalanceInUsd;
 }

--- a/app/lib/tender.ts
+++ b/app/lib/tender.ts
@@ -9,7 +9,7 @@ import SamplePriceOracleAbi from "~/config/sample-price-oracle-abi";
 
 import type { TokenPair } from "~/types/global";
 import { formatUnits } from "ethers/lib/utils";
-import type { JsonRpcSigner } from "@ethersproject/providers";
+import { TransactionReceipt, JsonRpcSigner } from "@ethersproject/providers";
 
 const MINIMUM_REQUIRED_APPROVAL_BALANCE = BigNumber.from("1");
 
@@ -77,7 +77,7 @@ async function deposit(
   cToken: cToken,
   token: Token
 ): Promise<{
-  wait: Function;
+  wait: () => TransactionReceipt;
 }> {
   // if (isCEth) {
   //   console.log("supply() w/ cEth");
@@ -116,7 +116,7 @@ async function redeem(
   cToken: cToken,
   token: Token
 ): Promise<{
-  wait: Function;
+  wait: () => TransactionReceipt;
 }> {
   // if (isCEth) {
   //   console.log("redeem() with cEth");
@@ -351,7 +351,7 @@ async function repay(
   cToken: cToken,
   token: Token
 ): Promise<{
-  wait: Function;
+  wait: () => TransactionReceipt;
 }> {
   const formattedValue: BigNumber = ethers.utils.parseUnits(
     value,
@@ -373,7 +373,7 @@ async function borrow(
   cToken: cToken,
   token: Token
 ): Promise<{
-  wait: Function;
+  wait: () => TransactionReceipt;
 }> {
   //  if (isCEth) {
   //   console.log("borrow() with cEth");

--- a/app/lib/tender.ts
+++ b/app/lib/tender.ts
@@ -9,7 +9,10 @@ import SamplePriceOracleAbi from "~/config/sample-price-oracle-abi";
 
 import type { TokenPair } from "~/types/global";
 import { formatUnits } from "ethers/lib/utils";
-import { TransactionReceipt, JsonRpcSigner } from "@ethersproject/providers";
+import type {
+  TransactionReceipt,
+  JsonRpcSigner,
+} from "@ethersproject/providers";
 
 const MINIMUM_REQUIRED_APPROVAL_BALANCE = BigNumber.from("1");
 

--- a/app/types/global.ts
+++ b/app/types/global.ts
@@ -44,6 +44,8 @@ export type TenderContext = {
   tokenPairs: TokenPair[];
   networkData: NetworkData;
   markets: Market[];
+  currentTransaction: string | null;
+  updateTransaction: Function;
 };
 
 export type Market = {


### PR DESCRIPTION
ref: https://app.asana.com/0/home/1201981678382625/1202233470943351

Example of a two-pronged approach to keep global state up to date:

* Use a cache buster at the context level we can call (the red button) https://github.com/tender-finance/tender-frontend/pull/58/files#diff-91fc88ef859119b5e2a2f7fd126e22f580d19855e3e98191145ceb1caae2d5ffL1
* Introduce a hook that polls https://github.com/tender-finance/tender-frontend/pull/58/files#diff-ce391c641839a0f635f07e552923c72d32577306e4a452dbe70238ab095858ccR1 and manually introduce in every hook we want to refresh like here https://github.com/tender-finance/tender-frontend/pull/58/files#diff-960ba7fe4d195bcbde4052f6ea623ecd59cb42118402f2e9822dabc8d261add0R12