### PR TITLE
Add market liquidity to borrow modal

### DIFF
--- a/app/components/borrow-flow/borrow.tsx
+++ b/app/components/borrow-flow/borrow.tsx
@@ -86,7 +86,9 @@ export default function Borrow({
     parseFloat(newBorrowLimitUsed)
   );
 
-  let inputTextClass = shrinkyInputClass(value.length);
+  let maxBorrowLiquidity = market.maxBorrowLiquidity;
+
+  inputTextClass = shrinkyInputClass(value.length);
 
   // Highlights value input
   useEffect(() => {
@@ -236,10 +238,16 @@ export default function Borrow({
                   )}
                 </div>
 
-                <div className="flex text-gray-500">
+                <div className="flex text-gray-500 mb-2">
                   <div className="flex-grow">Currently Borrowing</div>
                   <div>
                     {currentlyBorrowing} {market.tokenPair.token.symbol}
+                  </div>
+                </div>
+                <div className="flex text-gray-500">
+                  <div className="flex-grow">Borrow Liquidity</div>
+                  <div>
+                    {maxBorrowLiquidity} {market.tokenPair.token.symbol}
                   </div>
                 </div>
               </div>

--- a/app/components/borrow-flow/borrow.tsx
+++ b/app/components/borrow-flow/borrow.tsx
@@ -86,9 +86,7 @@ export default function Borrow({
     parseFloat(newBorrowLimitUsed)
   );
 
-  let maxBorrowLiquidity = market.maxBorrowLiquidity;
-
-  inputTextClass = shrinkyInputClass(value.length);
+  let inputTextClass = shrinkyInputClass(value.length);
 
   // Highlights value input
   useEffect(() => {
@@ -245,9 +243,10 @@ export default function Borrow({
                   </div>
                 </div>
                 <div className="flex text-gray-500">
-                  <div className="flex-grow">Borrow Liquidity</div>
+                  <div className="flex-grow">Market Liquidity</div>
                   <div>
-                    {maxBorrowLiquidity} {market.tokenPair.token.symbol}
+                    {market.maxBorrowLiquidity.toFixed(2)}{" "}
+                    {market.tokenPair.token.symbol}
                   </div>
                 </div>
               </div>

--- a/app/config/networks/metisStardust.ts
+++ b/app/config/networks/metisStardust.ts
@@ -8,8 +8,8 @@ export default {
   },
   Tokens: {
     tMETIS: {
-      name: "tMetis",
-      symbol: "tMETIS",
+      name: "Metis",
+      symbol: "METIS",
       decimals: 18,
       address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
       icon: "/images/coin-icons/metis.png",

--- a/app/hooks/use-markets.ts
+++ b/app/hooks/use-markets.ts
@@ -14,6 +14,7 @@ import {
   getTotalBorrowedUsd,
   getWalletBalance,
   getTotalBorrowedInUsd,
+  getMaxBorrowLiquidity,
 } from "~/lib/tender";
 import { useInterval } from "./use-interval";
 import { TenderContext } from "~/contexts/tender-context";

--- a/app/hooks/use-markets.ts
+++ b/app/hooks/use-markets.ts
@@ -88,6 +88,8 @@ export function useMarkets(
       let supplyBalanceInUsd = supplyBalance * tp.token.priceInUsd;
       let borrowBalanceInUsd = borrowBalance * tp.token.priceInUsd;
 
+      let maxBorrowLiquidity = await getMaxBorrowLiquidity(signer, tp.cToken);
+
       return {
         id: tp.token.symbol,
         tokenPair: tp,
@@ -108,6 +110,7 @@ export function useMarkets(
           totalBorrowedAmountInUsd,
           accountBorrowLimitInUsd
         ),
+        maxBorrowLiquidity,
       };
     });
 

--- a/app/hooks/use-markets.ts
+++ b/app/hooks/use-markets.ts
@@ -89,7 +89,7 @@ export function useMarkets(
       let supplyBalanceInUsd = supplyBalance * tp.token.priceInUsd;
       let borrowBalanceInUsd = borrowBalance * tp.token.priceInUsd;
 
-      let maxBorrowLiquidity = await getMaxBorrowLiquidity(signer, tp.cToken);
+      let maxBorrowLiquidity = await getMaxBorrowLiquidity(signer, tp);
 
       return {
         id: tp.token.symbol,

--- a/app/lib/tender.ts
+++ b/app/lib/tender.ts
@@ -1,5 +1,5 @@
 import type { cToken, Token } from "~/types/global";
-import type { Signer, Contract } from "ethers";
+import { Signer, Contract, utils } from "ethers";
 import { ethers, BigNumber } from "ethers";
 
 import SampleCTokenAbi from "~/config/sample-ctoken-abi";
@@ -616,9 +616,12 @@ async function getMaxBorrowLiquidity(
   );
 
   let totalSupply: BigNumber = await cTokenContract.totalSupply();
-  let totalReserve: BigNumber = await cTokenContract.totalReserve();
+  let totalReserves: BigNumber = await cTokenContract.totalReserves();
+  let totalBorrows: BigNumber = await cTokenContract.totalBorrows();
 
-  return await cTokenContract.redeemUnderlying(formattedValue);
+  let sum: BigNumber = totalSupply.add(totalReserves).sub(totalBorrows);
+
+  return parseFloat(utils.formatUnits(sum, 18));
 }
 
 export {
@@ -644,4 +647,5 @@ export {
   safeMaxBorrowAmountForToken,
   getMaxWithdrawAmount,
   getMaxBorrowAmount,
+  getMaxBorrowLiquidity,
 };

--- a/app/lib/tender.ts
+++ b/app/lib/tender.ts
@@ -605,6 +605,22 @@ async function getMaxBorrowAmount(
   return borrowableAmountInUsd / tp.token.priceInUsd;
 }
 
+async function getMaxBorrowLiquidity(
+  signer: JsonRpcSigner,
+  cToken: cToken
+): Promise<number> {
+  let cTokenContract = new ethers.Contract(
+    cToken.address,
+    SampleCTokenAbi,
+    signer
+  );
+
+  let totalSupply: BigNumber = await cTokenContract.totalSupply();
+  let totalReserve: BigNumber = await cTokenContract.totalReserve();
+
+  return await cTokenContract.redeemUnderlying(formattedValue);
+}
+
 export {
   enable,
   deposit,

--- a/app/lib/tender.ts
+++ b/app/lib/tender.ts
@@ -1,5 +1,5 @@
 import type { cToken, Token } from "~/types/global";
-import { Signer, Contract, utils } from "ethers";
+import { type Signer, type Contract, utils } from "ethers";
 import { ethers, BigNumber } from "ethers";
 
 import SampleCTokenAbi from "~/config/sample-ctoken-abi";

--- a/app/lib/tender.ts
+++ b/app/lib/tender.ts
@@ -607,21 +607,17 @@ async function getMaxBorrowAmount(
 
 async function getMaxBorrowLiquidity(
   signer: JsonRpcSigner,
-  cToken: cToken
+  tp: TokenPair
 ): Promise<number> {
   let cTokenContract = new ethers.Contract(
-    cToken.address,
+    tp.cToken.address,
     SampleCTokenAbi,
     signer
   );
 
-  let totalSupply: BigNumber = await cTokenContract.totalSupply();
-  let totalReserves: BigNumber = await cTokenContract.totalReserves();
-  let totalBorrows: BigNumber = await cTokenContract.totalBorrows();
+  let balance: BigNumber = await cTokenContract.getCash();
 
-  let sum: BigNumber = totalSupply.add(totalReserves).sub(totalBorrows);
-
-  return parseFloat(utils.formatUnits(sum, 18));
+  return parseFloat(utils.formatUnits(balance, tp.token.decimals));
 }
 
 export {

--- a/app/types/global.ts
+++ b/app/types/global.ts
@@ -73,4 +73,5 @@ export type Market = {
   borrowLimitUsed: string;
   totalBorrowedAmountInUsd: number;
   comptrollerAddress: string;
+  maxBorrowLiquidity: number;
 };


### PR DESCRIPTION
Added max liquidity to borrow modal. The function on the contract is basically a wrapper for `balanceOf(theERC20Underlying)` and that appears to work well.

<img width="657" alt="image" src="https://user-images.githubusercontent.com/3760568/171725416-10276cc8-954b-49bc-a1ac-c999c2905c83.png">
