### PR TITLE
Hide pane overflows

### DIFF
--- a/app/components/two-panes.tsx
+++ b/app/components/two-panes.tsx
@@ -29,7 +29,7 @@ export default function TwoPanes() {
             <div className="px-8 py-6 text-brand-green text-2xl border-b border-b-gray-600 mb-4">
               Supply
             </div>
-            <table className="w-full h-full">
+            <table className="w-full h-full table-fixed">
               <thead>
                 <tr className="text-xs text-gray-400 ">
                   <th className="pb-4 px-8 text-left">Asset</th>
@@ -71,7 +71,7 @@ export default function TwoPanes() {
         )}
         {marketsWithoutSupply.length > 0 && (
           <div className="pane py-6">
-            <table className="w-full h-full">
+            <table className="w-full h-full table-fixed">
               <thead>
                 <tr className="text-xs text-gray-400 ">
                   <th className="pb-4 px-8 text-left">Asset</th>
@@ -126,7 +126,7 @@ export default function TwoPanes() {
             <div className="px-8 py-6 text-brand-blue text-2xl border-b border-b-gray-600 mb-4">
               Borrowing
             </div>
-            <table className="w-full h-full">
+            <table className="w-full h-full table-fixed">
               <thead>
                 <tr className="text-xs text-gray-400 ">
                   <th className="pb-4 px-8 text-left">Assets</th>
@@ -178,7 +178,7 @@ export default function TwoPanes() {
         )}
         {marketsWithoutBorrow.length > 0 && (
           <div className="pane py-6">
-            <table className="w-full h-full">
+            <table className="w-full h-full table-fixed">
               <thead>
                 <tr className="text-xs text-gray-400 ">
                   <th className="pb-4 px-8 text-left">Asset</th>

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -20,6 +20,8 @@
     );
     box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.07);
 
+    overflow-x: hidden;
+
     @apply rounded-2xl;
   }
 }


### PR DESCRIPTION
* Adds extra protection for table overflow is there are very large numbers in the Panes
* Adds `table-fixed` to prevent tables from adjusting too much based on content and breaking UI

![CleanShot 2022-06-07 at 15 26 30](https://user-images.githubusercontent.com/1318878/172475999-0f9311ea-5811-4745-a700-dce9ae43a451.png)

