### PR TITLE
Don’t format the max repayable amount, we want the full thing.

### DIFF
--- a/app/components/borrow-flow/repay.tsx
+++ b/app/components/borrow-flow/repay.tsx
@@ -145,12 +145,12 @@ export default function Repay({
                     defaultValue={0}
                   />
                   <Max
-                    maxValue={maxRepayableAmount.toFixed(2)}
+                    maxValue={maxRepayableAmount.toString()}
                     updateValue={() => {
                       if (!inputEl || !inputEl.current) return;
                       inputEl.current.focus();
-                      inputEl.current.value = maxRepayableAmount.toFixed(2);
-                      setValue(maxRepayableAmount.toFixed(2));
+                      inputEl.current.value = maxRepayableAmount.toString();
+                      setValue(maxRepayableAmount.toString());
                     }}
                     maxValueLabel={market.tokenPair.token.symbol}
                   />


### PR DESCRIPTION
before

<img width="607" alt="Screen Shot 2022-06-07 at 5 05 44 PM" src="https://user-images.githubusercontent.com/3760568/172491126-2040cca2-8b9a-48ca-a5d6-80b3be6d10ee.png">

after 
<img width="716" alt="Screen Shot 2022-06-07 at 5 06 36 PM" src="https://user-images.githubusercontent.com/3760568/172491152-d7f28cc0-c3e9-4975-9f23-c451f0cdd072.png">

