### PR TITLE
[Fix] remember entered values in supply-withdraw and borrow-repay

### DIFF
--- a/app/components/borrow-flow/borrow-flow.tsx
+++ b/app/components/borrow-flow/borrow-flow.tsx
@@ -13,19 +13,37 @@ interface Props {
   market: Market;
 }
 
+type ActiveTab = "repay" | "borrow";
+
 export default function BorrowFlow({ closeModal, market }: Props) {
-  let [isRepaying, setIsRepaying] = useState<boolean>(false);
+  const [activeTab, setActiveTab] = useState<ActiveTab>("borrow");
+  const [initialRepayValue, setInitialRepayValue] = useState<string>("");
+  const [initialBorrowValue, setInitialBorrowValue] = useState<string>("");
 
   let { tokenPairs } = useContext(TenderContext);
 
   let provider = Web3Hooks.useProvider();
   const signer = useWeb3Signer(provider);
 
-  return isRepaying ? (
+  
+  const handleTabSwitch = (tab: ActiveTab, lastValue?: string) => {
+    setActiveTab(tab);
+
+    //skip setting initial value if user is clicking on same tab or lastvalue is undefined
+    if (activeTab === tab || lastValue === undefined) return;
+
+    if (tab === "borrow") {
+      setInitialRepayValue(lastValue);
+    } else if (tab === "repay") {
+      setInitialBorrowValue(lastValue);
+    }
+  };
+
+  return activeTab ==='repay' ? (
     <Repay
       market={market}
       closeModal={closeModal}
-      setIsRepaying={setIsRepaying}
+      onTabSwitch={handleTabSwitch}
       borrowedAmount={market.borrowBalance}
       signer={signer}
       borrowLimitUsed={market.borrowLimitUsed}
@@ -33,18 +51,20 @@ export default function BorrowFlow({ closeModal, market }: Props) {
       tokenPairs={tokenPairs}
       borrowLimit={market.borrowLimit}
       totalBorrowedAmountInUsd={market.totalBorrowedAmountInUsd}
+      initialValue={initialRepayValue}
     />
   ) : (
     <Borrow
       market={market}
       closeModal={closeModal}
-      setIsRepaying={setIsRepaying}
+      onTabSwitch={handleTabSwitch}
       signer={signer}
       borrowLimitUsed={market.borrowLimitUsed}
       borrowLimit={market.borrowLimit}
       walletBalance={market.walletBalance}
       tokenPairs={tokenPairs}
       totalBorrowedAmountInUsd={market.totalBorrowedAmountInUsd}
+      initialValue={initialBorrowValue}
     />
   );
 }

--- a/app/components/borrow-flow/borrow.tsx
+++ b/app/components/borrow-flow/borrow.tsx
@@ -86,7 +86,7 @@ export default function Borrow({
   let inputTextClass = shrinkyInputClass(value.length);
   // Highlights value input
   useEffect(() => {
-    inputEl && inputEl.current && inputEl.current.select();
+    inputEl && inputEl.current && inputEl.current.focus();
   }, []);
 
   const handleCheckValue = useCallback(

--- a/app/components/borrow-flow/borrow.tsx
+++ b/app/components/borrow-flow/borrow.tsx
@@ -27,27 +27,29 @@ import { formatApy } from "~/lib/apy-calculations";
 export interface BorrowProps {
   market: Market;
   closeModal: Function;
-  setIsRepaying: Function;
+  onTabSwitch: Function;
   signer: JsonRpcSigner | null | undefined;
   borrowLimitUsed: string;
   borrowLimit: number;
   walletBalance: number;
   tokenPairs: TokenPair[];
   totalBorrowedAmountInUsd: number;
+  initialValue: string;
 }
 
 export default function Borrow({
   market,
   closeModal,
-  setIsRepaying,
+  onTabSwitch,
   signer,
   borrowLimit,
   borrowLimitUsed,
   totalBorrowedAmountInUsd,
+  initialValue,
 }: BorrowProps) {
   const tokenDecimals = market.tokenPair.token.decimals;
 
-  let [value, setValue] = useState<string>("");
+  let [value, setValue] = useState<string>(initialValue);
   let [isBorrowing, setIsBorrowing] = useState<boolean>(false);
   let [txnHash, setTxnHash] = useState<string>("");
 
@@ -175,13 +177,13 @@ export default function Borrow({
             <div className="flex mt-6 uppercase">
               <button
                 className="flex-grow py-2 text-[#00E0FF] border-b-4 uppercase border-b-[#00E0FF] font-space font-bold text-xs sm:text-base"
-                onClick={() => setIsRepaying(false)}
+                onClick={() => onTabSwitch("borrow")}
               >
                 Borrow
               </button>
               <button
                 className="flex-grow py-3 font-space font-bold text-xs sm:text-base uppercase"
-                onClick={() => setIsRepaying(true)}
+                onClick={() => onTabSwitch("repay", value)}
               >
                 Repay
               </button>

--- a/app/components/borrow-flow/repay.tsx
+++ b/app/components/borrow-flow/repay.tsx
@@ -104,7 +104,7 @@ export default function Repay({
 
   // Highlights value input
   useEffect(() => {
-    inputEl && inputEl.current && inputEl.current.select();
+    inputEl && inputEl.current && inputEl.current.focus();
   }, [loading]);
 
   // @todo refactor: move to separate hook file

--- a/app/components/borrow-flow/repay.tsx
+++ b/app/components/borrow-flow/repay.tsx
@@ -25,7 +25,7 @@ import { formatApy } from "~/lib/apy-calculations";
 
 export interface RepayProps {
   closeModal: Function;
-  setIsRepaying: Function;
+  onTabSwitch: Function;
   signer: JsonRpcSigner | null | undefined;
   borrowedAmount: number;
   borrowLimitUsed: string;
@@ -34,18 +34,20 @@ export interface RepayProps {
   tokenPairs: TokenPair[];
   totalBorrowedAmountInUsd: number;
   market: Market;
+  initialValue: string;
 }
 
 export default function Repay({
   market,
   closeModal,
-  setIsRepaying,
+  onTabSwitch,
   signer,
   borrowedAmount,
   borrowLimit,
   borrowLimitUsed,
   walletBalance,
   totalBorrowedAmountInUsd,
+  initialValue,
 }: RepayProps) {
   const tokenDecimals = market.tokenPair.token.decimals;
 
@@ -54,7 +56,7 @@ export default function Repay({
   let [loading, setLoading] = useState<boolean>(true);
 
   let [isRepayingTxn, setIsRepayingTxn] = useState<boolean>(false);
-  let [value, setValue] = useState<string>("");
+  let [value, setValue] = useState<string>(initialValue);
   let [txnHash, setTxnHash] = useState<string>("");
 
   let maxRepayableAmount = Math.min(borrowedAmount, walletBalance);
@@ -211,13 +213,13 @@ export default function Repay({
             <div className="flex mt-6 uppercase">
               <button
                 className="flex-grow py-3 font-space font-bold text-xs sm:text-base uppercase"
-                onClick={() => setIsRepaying(false)}
+                onClick={() => onTabSwitch("borrow", value)}
               >
                 Borrow
               </button>
               <button
                 className="flex-grow py-2 text-[#00E0FF] border-b-4 uppercase border-b-[#00E0FF] font-space font-bold text-xs sm:text-base"
-                onClick={() => setIsRepaying(true)}
+                onClick={() => onTabSwitch("repay")}
               >
                 Repay
               </button>

--- a/app/components/deposit-flow/deposit-flow.tsx
+++ b/app/components/deposit-flow/deposit-flow.tsx
@@ -12,34 +12,53 @@ interface Props {
   market: Market;
 }
 
+type ActiveTab = "supply" | "withdraw";
+
 export default function DepositFlow({ closeModal, market }: Props) {
-  let [isSupplying, setIsSupplying] = useState<boolean>(true);
+  const [activeTab, setActiveTab] = useState<ActiveTab>("supply");
+  const [initialSupplyValue, setInitialSupplyValue] = useState<string>("");
+  const [initialWithdrawValue, setInitialWithdrawValue] = useState<string>("");
 
   let provider = Web3Hooks.useProvider();
   const signer = useWeb3Signer(provider);
 
-  return isSupplying ? (
+  const handleTabSwitch = (tab: ActiveTab, lastValue?: string) => {
+    setActiveTab(tab);
+
+    //skip setting initial value if user is clicking on same tab or lastvalue is undefined
+    if (activeTab === tab || lastValue === undefined) return;
+
+    if (tab === "supply") {
+      setInitialWithdrawValue(lastValue);
+    } else if (tab === "withdraw") {
+      setInitialSupplyValue(lastValue);
+    }
+  };
+
+  return activeTab === "supply" ? (
     <Deposit
       closeModal={closeModal}
       market={market}
-      setIsSupplying={setIsSupplying}
+      onTabSwitch={handleTabSwitch}
       borrowLimit={market.borrowLimit}
       borrowLimitUsed={market.borrowLimitUsed}
       signer={signer}
       walletBalance={market.walletBalance}
       totalBorrowedAmountInUsd={market.totalBorrowedAmountInUsd}
       comptrollerAddress={market.comptrollerAddress}
+      initialValue={initialSupplyValue}
     />
   ) : (
     <Withdraw
       market={market}
       closeModal={closeModal}
-      setIsSupplying={setIsSupplying}
+      onTabSwitch={handleTabSwitch}
       borrowLimit={market.borrowLimit}
       borrowLimitUsed={market.borrowLimitUsed}
       signer={signer}
       walletBalance={market.walletBalance}
       totalBorrowedAmountInUsd={market.totalBorrowedAmountInUsd}
+      initialValue={initialWithdrawValue}
     />
   );
 }

--- a/app/components/deposit-flow/deposit.tsx
+++ b/app/components/deposit-flow/deposit.tsx
@@ -23,24 +23,26 @@ import { useCollateralFactor } from "~/hooks/use-collateral-factor";
 export interface DepositProps {
   closeModal: Function;
   market: Market;
-  setIsSupplying: Function;
+  onTabSwitch: Function;
   borrowLimit: number;
   signer: JsonRpcSigner | null | undefined;
   borrowLimitUsed: string;
   walletBalance: number;
   totalBorrowedAmountInUsd: number;
   comptrollerAddress: string;
+  initialValue: string;
 }
 export default function Deposit({
   closeModal,
   comptrollerAddress,
-  setIsSupplying,
+  onTabSwitch,
   borrowLimit,
   signer,
   borrowLimitUsed,
   walletBalance,
   totalBorrowedAmountInUsd,
   market,
+  initialValue
 }: DepositProps) {
   const tokenDecimals = market.tokenPair.token.decimals;
 
@@ -48,7 +50,7 @@ export default function Deposit({
   let [loading, setLoading] = useState<boolean>(true);
   let [isEnabling, setIsEnabling] = useState<boolean>(false);
   let [isDepositing, setIsDepositing] = useState<boolean>(false);
-  let [value, setValue] = useState<string>("");
+  let [value, setValue] = useState<string>(initialValue);
   let [txnHash, setTxnHash] = useState<string>("");
   let inputTextClass = shrinkyInputClass(value.length);
 
@@ -206,13 +208,13 @@ export default function Deposit({
             <div className="flex mt-6 uppercase">
               <button
                 className="flex-grow py-2 text-[#14F195] border-b-4 uppercase border-b-[#14F195] font-space font-bold text-xs sm:text-base"
-                onClick={() => setIsSupplying(true)}
+                onClick={() => onTabSwitch('supply')}
               >
                 Supply
               </button>
               <button
                 className="flex-grow py-3 font-space font-bold text-xs sm:text-base uppercase"
-                onClick={() => setIsSupplying(false)}
+                onClick={() => onTabSwitch('withdraw', value)}
               >
                 Withdraw
               </button>

--- a/app/components/deposit-flow/deposit.tsx
+++ b/app/components/deposit-flow/deposit.tsx
@@ -103,7 +103,7 @@ export default function Deposit({
 
   // Highlights value input
   useEffect(() => {
-    inputEl && inputEl.current && inputEl.current.select();
+    inputEl && inputEl.current && inputEl.current.focus();
   }, [loading]);
 
   const handleCheckValue = useCallback(

--- a/app/components/deposit-flow/withdraw.tsx
+++ b/app/components/deposit-flow/withdraw.tsx
@@ -89,7 +89,7 @@ export default function Withdraw({
 
   // Highlights value input
   useEffect(() => {
-    inputEl && inputEl.current && inputEl.current.select();
+    inputEl && inputEl.current && inputEl.current.focus();
   }, []);
 
   const handleCheckValue = useCallback(

--- a/app/components/deposit-flow/withdraw.tsx
+++ b/app/components/deposit-flow/withdraw.tsx
@@ -19,25 +19,27 @@ import { useCollateralFactor } from "~/hooks/use-collateral-factor";
 export interface WithdrawProps {
   market: Market;
   closeModal: Function;
-  setIsSupplying: Function;
+  onTabSwitch: Function;
   borrowLimit: number;
   signer: JsonRpcSigner | null | undefined;
   borrowLimitUsed: string;
   walletBalance: number;
   totalBorrowedAmountInUsd: number;
+  initialValue: string;
 }
 export default function Withdraw({
   market,
   closeModal,
-  setIsSupplying,
+  onTabSwitch,
   borrowLimit,
   signer,
   borrowLimitUsed,
   totalBorrowedAmountInUsd,
+  initialValue,
 }: WithdrawProps) {
   const tokenDecimals = market.tokenPair.token.decimals;
 
-  let [value, setValue] = useState<string>("");
+  let [value, setValue] = useState<string>(initialValue);
   let [isWithdrawing, setIsWithdrawing] = useState<boolean>(false);
   let [txnHash, setTxnHash] = useState<string>("");
   let inputEl = useRef<HTMLInputElement>(null);
@@ -175,13 +177,13 @@ export default function Withdraw({
             <div className="flex mt-6 uppercase">
               <button
                 className="flex-grow py-3 font-space font-bold text-xs sm:text-base uppercase"
-                onClick={() => setIsSupplying(true)}
+                onClick={() => onTabSwitch("supply", value)}
               >
                 Supply
               </button>
               <button
                 className="flex-grow py-2 text-[#14F195] border-b-4 uppercase border-b-[#14F195] font-space font-bold text-xs sm:text-base"
-                onClick={() => setIsSupplying(false)}
+                onClick={() => onTabSwitch("withdraw")}
               >
                 Withdraw
               </button>

--- a/stories/app/components/borrow-flow/borrow.stories.tsx
+++ b/stories/app/components/borrow-flow/borrow.stories.tsx
@@ -75,13 +75,14 @@ let tokenPairs: TokenPair[] = [tokenPair];
 Primary.args = {
   market,
   closeModal: () => {},
-  setIsRepaying: () => {},
+  onTabSwitch: () => {},
   signer: null,
   borrowLimitUsed: market.borrowLimitUsed,
   borrowLimit: market.borrowLimit,
   walletBalance: market.walletBalance,
   tokenPairs,
   totalBorrowedAmountInUsd: market.borrowBalanceInUsd,
+  initialValue: ""
 } as BorrowProps;
 
 let smallMarket = {
@@ -106,7 +107,7 @@ let smallMarket = {
 };
 SmallNumbers.args = {
   closeModal: () => {},
-  setIsRepaying: () => {},
+  onTabSwitch: () => {},
   signer: null,
   borrowLimitUsed: smallMarket.borrowLimitUsed,
   borrowLimit: smallMarket.borrowLimit,
@@ -114,4 +115,5 @@ SmallNumbers.args = {
   tokenPairs,
   totalBorrowedAmountInUsd: smallMarket.borrowBalanceInUsd,
   market: smallMarket,
+  initialValue: ""
 } as BorrowProps;

--- a/stories/app/components/borrow-flow/repay.stories.tsx
+++ b/stories/app/components/borrow-flow/repay.stories.tsx
@@ -75,7 +75,7 @@ let tokenPairs: TokenPair[] = [tokenPair];
 Primary.args = {
   market,
   closeModal: () => {},
-  setIsRepaying: () => {},
+  onTabSwitch: () => {},
   signer: null,
   borrowLimit: market.borrowLimit,
   borrowedAmount: market.borrowBalance,
@@ -83,6 +83,7 @@ Primary.args = {
   tokenPairs,
   borrowLimitUsed: market.borrowLimitUsed,
   totalBorrowedAmountInUsd: market.totalBorrowedAmountInUsd,
+  initialValue: ""
 } as RepayProps;
 
 let smallMarket: Market = {
@@ -109,7 +110,7 @@ let smallMarket: Market = {
 SmallNumbers.args = {
   market: smallMarket,
   closeModal: () => {},
-  setIsRepaying: () => {},
+  onTabSwitch: () => {},
   signer: null,
   borrowLimit: smallMarket.borrowLimit,
   borrowedAmount: smallMarket.borrowBalance,
@@ -117,4 +118,5 @@ SmallNumbers.args = {
   tokenPairs,
   borrowLimitUsed: smallMarket.borrowLimitUsed,
   totalBorrowedAmountInUsd: smallMarket.totalBorrowedAmountInUsd,
+  initialValue: ""
 } as RepayProps;

--- a/stories/app/components/deposit-flow/deposit.stories.tsx
+++ b/stories/app/components/deposit-flow/deposit.stories.tsx
@@ -77,7 +77,7 @@ let tokenPairs: TokenPair[] = [tokenPair];
 Primary.args = {
   market,
   closeModal: () => {},
-  setIsSupplying: () => {},
+  onTabSwitch: () => {},
   signer: null,
   borrowLimit: market.borrowLimit,
   borrowLimitUsed: market.borrowLimitUsed,
@@ -85,6 +85,7 @@ Primary.args = {
   tokenPairs,
   totalBorrowedAmountInUsd: market.totalBorrowedAmountInUsd,
   comptrollerAddress: market.comptrollerAddress,
+  initialValue: ""
 } as DepositProps;
 
 let smallMarket: Market = {
@@ -112,7 +113,7 @@ let smallMarket: Market = {
 SmallNumbers.args = {
   market: smallMarket,
   closeModal: () => {},
-  setIsSupplying: () => {},
+  onTabSwitch: () => {},
   signer: null,
   borrowLimit: smallMarket.borrowLimit,
   borrowLimitUsed: smallMarket.borrowLimitUsed,
@@ -120,4 +121,5 @@ SmallNumbers.args = {
   tokenPairs,
   totalBorrowedAmountInUsd: smallMarket.totalBorrowedAmountInUsd,
   comptrollerAddress: smallMarket.comptrollerAddress,
+  initialValue: ""
 } as DepositProps;

--- a/stories/app/components/deposit-flow/withdraw.stories.tsx
+++ b/stories/app/components/deposit-flow/withdraw.stories.tsx
@@ -77,7 +77,7 @@ let tokenPairs: TokenPair[] = [tokenPair];
 Primary.args = {
   market,
   closeModal: () => {},
-  setIsSupplying: () => {},
+  onTabSwitch: () => {},
   signer: null,
   borrowLimit: market.borrowLimit,
   borrowLimitUsed: market.borrowLimitUsed,
@@ -85,6 +85,7 @@ Primary.args = {
   tokenPairs,
   totalBorrowedAmountInUsd: market.totalBorrowedAmountInUsd,
   comptrollerAddress: market.comptrollerAddress,
+  initialValue: ""
 } as WithdrawProps;
 
 let smallMarket: Market = {
@@ -112,7 +113,7 @@ let smallMarket: Market = {
 SmallNumbers.args = {
   market,
   closeModal: () => {},
-  setIsSupplying: () => {},
+  onTabSwitch: () => {},
   signer: null,
   borrowLimit: smallMarket.borrowLimit,
   borrowLimitUsed: smallMarket.borrowLimitUsed,
@@ -120,4 +121,5 @@ SmallNumbers.args = {
   tokenPairs,
   totalBorrowedAmountInUsd: smallMarket.totalBorrowedAmountInUsd,
   comptrollerAddress: smallMarket.comptrollerAddress,
+  initialValue: ""
 } as WithdrawProps;


### PR DESCRIPTION
- last entered value in supply and withdraw saved to parent component
- last entered value set as initialValue when component is mounted
- applied same logic to borrow-repay