### PR TITLE
[Fix] fix max value display issues

### DIFF
--- a/app/components/max.tsx
+++ b/app/components/max.tsx
@@ -1,4 +1,4 @@
-import { toMaxString } from "~/lib/ui";
+import { getDisplayPriceString } from "~/lib/ui";
 
 interface MaxProps {
   updateValue: Function;
@@ -20,7 +20,7 @@ export default function Max(props: MaxProps) {
       <div
         className={`text-[${props.color}] custom_max_text font-nova font-bold text-xs sm:text-base mb-4`}
       >
-        {toMaxString(props.maxValue) + " " + props.maxValueLabel}
+        {getDisplayPriceString(props.maxValue) + " " + props.maxValueLabel}
       </div>
 
       <button

--- a/app/lib/ui.ts
+++ b/app/lib/ui.ts
@@ -81,8 +81,7 @@ export const toCryptoString = (v: number): string => {
   return s;
 };
 
-export const toMaxString = (v: number): string =>
-  (toMaxNumber(v) * 1).toString();
+export const toMaxString = (v: number): string => getString(v);
 
 export const toMaxNumber = (v: number): number =>
   parseFloat(
@@ -91,5 +90,14 @@ export const toMaxNumber = (v: number): number =>
       precision: 6,
     })
   );
+
+// return decimal with precision 4 for values less than 1 and round to 2 decimals for nmumber greater than 1
+export const getDisplayPriceString = (v: number) =>
+  Intl.NumberFormat("en-US", {
+    notation: "standard",
+    maximumSignificantDigits: v < 1 ? 4 : undefined,
+  }).format(v);
+
+export const getString = (v: number) => math.format(v, { notation: "fixed" });
 
 export { shrinkyInputClass };


### PR DESCRIPTION
- when displaying smaller values use precision of 4 numbers
- when displaying number greater than 1, round to 2 decimals
- when using on input fields, always give full value without any rounding or precision