### PR TITLE
[Fix]: Max available amount in borrow modal [DRAFT-DO-NOT-MERGE]

### DIFF
--- a/app/components/borrow-flow/borrow.tsx
+++ b/app/components/borrow-flow/borrow.tsx
@@ -77,7 +77,7 @@ export default function Borrow({
   let [isValid, validationDetail] = useValidInput(
     value,
     0,
-    maxBorrowLimit,
+    borrowLimit,
     parseFloat(newBorrowLimitUsed)
   );
 
@@ -164,7 +164,7 @@ export default function Borrow({
               />
               {parseFloat(borrowLimitUsed) < 80 && (
                 <Max
-                  maxValue={maxBorrowLimit}
+                  maxValue={borrowLimit}
                   updateValue={() => setValue(toMaxString(maxBorrowLimit))}
                   maxValueLabel={market.tokenPair.token.symbol}
                   label="80% Max"


### PR DESCRIPTION
- max available amount changed to borrowLimit
- 80% Max is on top of the max available amount
- validation check of insufficient liquidity is now done over borrowLimit value