### PR TITLE
[Fix] keep dollar amount in same format

### DIFF
--- a/app/lib/ui.test.ts
+++ b/app/lib/ui.test.ts
@@ -1,0 +1,25 @@
+import { assert, describe, it } from "vitest";
+import { toShortCryptoString } from "./ui";
+
+describe("lib/ui", () => {
+  describe("toShortCryptoString", () => {
+    it("should format number with decimals", () => {
+      // number greater than 1
+      assert.equal(toShortCryptoString(2.0999), "2.10");
+      assert.equal(toShortCryptoString(9000), "9,000.00");
+      assert.equal(toShortCryptoString(100099.8888), "100k");
+      assert.equal(toShortCryptoString(100999.8888), "101k");
+      assert.equal(toShortCryptoString(123456.8888), "123k");
+      
+      //number less than 1
+      assert.equal(toShortCryptoString(1), "1.00");
+      assert.equal(toShortCryptoString(0.99), "0.99");
+      assert.equal(toShortCryptoString(0.9999999999), "1.00");
+      assert.equal(toShortCryptoString(0.2222222222), "0.222222");
+      assert.equal(toShortCryptoString(0.5555555555), "0.555556");
+      assert.equal(toShortCryptoString(0.0000005), "0.00");
+      assert.equal(toShortCryptoString(0.0000006), "0.000001");
+      assert.equal(toShortCryptoString(0), "0.00");
+    });
+  });
+});

--- a/app/lib/ui.ts
+++ b/app/lib/ui.ts
@@ -42,7 +42,8 @@ export const toFiatString = (v: number): string => {
   return `${roundedNumber.toLocaleString("en-US", {
     // style: "currency",
     currency: "USD",
-  })}`;
+    minimumFractionDigits: 2
+  })}`
 };
 
 const A_BIG_NUMBER = 100000;

--- a/app/lib/ui.ts
+++ b/app/lib/ui.ts
@@ -74,10 +74,12 @@ export const toCryptoString = (v: number): string => {
     s = v
       .toFixed(7) // round to 7 places instead of 6
       .slice(0, -1); // then drop the last digit because rounding up breaks the upper limit
-
-    // note, safari does not support regexp look behind
-    // If there is a decimal, remove traliing 0's, leaving at least one left
-    if (s.indexOf(".") !== -1) s = s.replace(/0+$/g, "0");
+      
+    s = Intl.NumberFormat("en-US", {
+      notation: "standard",
+      minimumFractionDigits:2,
+      maximumFractionDigits:6
+    }).format(v);
   }
   return s;
 };


### PR DESCRIPTION
- All usd values to have 2 decimal points 
- fix crypto string which was adding a trailing zero at end
- added test case to check the values